### PR TITLE
Fix: getSerialized breaks Google clientId

### DIFF
--- a/models/ConfigureForm.php
+++ b/models/ConfigureForm.php
@@ -75,7 +75,7 @@ class ConfigureForm extends Model
         $settings = $module->settings;
 
         $this->enabled = (boolean)$settings->get('enabled');
-        $this->clientId = $settings->getSerialized('clientId');
+        $this->clientId = $settings->get('clientId');
         $this->clientSecret = $settings->get('clientSecret');
 
         $this->redirectUri = Url::to(['/user/auth/external', 'authclient' => 'google'], true);


### PR DESCRIPTION
Using `getSerialized()` causes the following error, this p/r fixes this error

```logs
yii\base\InvalidArgumentException: Syntax error. in /home/USER/public_html/protected/vendor/yiisoft/yii2/helpers/BaseJson.php:133 Stack trace:
#0 /home/USER/public_html/protected/vendor/yiisoft/yii2/helpers/BaseJson.php(107): yii\helpers\BaseJson::handleJsonError(4)
#1 /home/USER/public_html/protected/humhub/libs/BaseSettingsManager.php(112): yii\helpers\BaseJson::decode('284078925011-08...')
#2 /home/USER/public_html/protected/modules/auth-google/models/ConfigureForm.php(78): humhub\libs\BaseSettingsManager->getSerialized('clientId')
#3 /home/USER/public_html/protected/modules/auth-google/models/ConfigureForm.php(105): humhubContrib\auth\google\models\ConfigureForm->loadSettings()
#4 /home/USER/public_html/protected/modules/auth-google/controllers/AdminController.php(22): humhubContrib\auth\google\models\ConfigureForm::getInstance()
#5 [internal function]: humhubContrib\auth\google\controllers\AdminController->actionIndex()
#6 /home/USER/public_html/protected/vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array(Array, Array)
#7 /home/USER/public_html/protected/vendor/yiisoft/yii2/base/Controller.php(180): yii\base\InlineAction->runWithParams(Array)
#8 /home/USER/public_html/protected/vendor/yiisoft/yii2/base/Module.php(528): yii\base\Controller->runAction('', Array)
#9 /home/USER/public_html/protected/vendor/yiisoft/yii2/web/Application.php(103): yii\base\Module->runAction('auth-google/adm...', Array)
#10 /home/USER/public_html/protected/vendor/yiisoft/yii2/base/Application.php(386): yii\web\Application->handleRequest(Object(humhub\components\Request))
#11 /home/USER/public_html/index.php(25): yii\base\Application->run()
#12 {main}
```